### PR TITLE
Add support for neutral Languages: Show languagecode instead of flag

### DIFF
--- a/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-detail.tpl.html
+++ b/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-detail.tpl.html
@@ -29,7 +29,8 @@
                         <ui-select ng-model="blade.currentEntity.languageCode">
                             <ui-select-match allow-clear placeholder="{{'core.blades.seo-detail.placeholders.language' | translate}}">{{$select.selected}}</ui-select-match>
                             <ui-select-choices repeat="x in blade.languages">
-                                <span class="flag flag-{{x.substr(3).toLowerCase()}}"></span>
+                                <span ng-if="x.length>2" class="flag flag-{{x.substr(3).toLowerCase()}}"></span>
+                                <span ng-if="x.length<=2" class="langCode">{{x.toUpperCase()}}</span>
                                 <span ng-bind-html="x"></span>
                             </ui-select-choices>
                         </ui-select>


### PR DESCRIPTION
Using a neutral language instead of a specific language in Virto causes multilingual fields to not show flags. Flags are determined by taking the country part of a specific Language. This change replaces the flag by the two letter culturecode in case of neutral languages. For specific languages, nothing will change.

Also see PullRequests on vc-module-catalog and vc-platform for related changes.