### PR TITLE
Fix error shown on index widget even when entity was indexed after it was modified.

### DIFF
--- a/VirtoCommerce.CoreModule.Web/Scripts/SearchIndex/widgets/index-widget.js
+++ b/VirtoCommerce.CoreModule.Web/Scripts/SearchIndex/widgets/index-widget.js
@@ -1,42 +1,43 @@
-﻿angular.module('virtoCommerce.coreModule.searchIndex')
-.controller('virtoCommerce.coreModule.searchIndex.indexWidgetController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.coreModule.searchIndex.searchIndexation', function ($scope, bladeNavigationService, searchApi) {
-    var blade = $scope.blade;
-    $scope.loading = true;
+angular.module('virtoCommerce.coreModule.searchIndex')
+    .controller('virtoCommerce.coreModule.searchIndex.indexWidgetController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.coreModule.searchIndex.searchIndexation', function ($scope, bladeNavigationService, searchApi) {
+        var blade = $scope.blade;
+        var momentFormat = "YYYYMMDDHHmmss";
+        $scope.loading = true;
 
-    function refresh() {
-        searchApi.getDocIndex({ documentType: $scope.widget.documentType, documentId: blade.currentEntityId }, function (data) {
-            if (_.any(data)) {
-                $scope.index = data[0];
-                $scope.indexDate = moment.utc($scope.index.indexationdate, 'YYYYMMDDHHmmss');
-            }
+        function refresh() {
+            searchApi.getDocIndex({ documentType: $scope.widget.documentType, documentId: blade.currentEntityId }, function (data) {
+                if (_.any(data)) {
+                    $scope.index = data[0];
+                    $scope.indexDate = moment.utc($scope.index.indexationdate, momentFormat);
+                }
 
-            $scope.loading = false;
-            updateStatus();
-        });
-    }
-
-    function updateStatus() {
-        if (!$scope.loading && blade.currentEntity) {
-            $scope.widget.UIclass = !$scope.index || ($scope.indexDate < moment.utc(blade.currentEntity.modifiedDate)) ? 'error' : '';
+                $scope.loading = false;
+                updateStatus();
+            });
         }
-    }
 
-    $scope.openBlade = function () {
-        var newBlade = {
-            id: 'detailChild',
-            currentEntityId: blade.currentEntityId,
-            currentEntity: blade.currentEntity,
-            data: $scope.index,
-            indexDate: $scope.indexDate,
-            documentType: $scope.widget.documentType,
-            parentRefresh: refresh,         
-            controller: 'virtoCommerce.coreModule.searchIndex.indexDetailController',
-            template: 'Modules/$(VirtoCommerce.Core)/Scripts/SearchIndex/blades/index-detail.tpl.html'
-        };       
-        bladeNavigationService.showBlade(newBlade, blade);
-    };
+        function updateStatus() {
+            if (!$scope.loading && blade.currentEntity) {
+                $scope.widget.UIclass = !$scope.index || ($scope.indexDate.isBefore(moment.utc(blade.currentEntity.modifiedDate, momentFormat))) ? 'error' : '';
+            }
+        }
 
-    $scope.$watch('blade.currentEntity', updateStatus);
+        $scope.openBlade = function () {
+            var newBlade = {
+                id: 'detailChild',
+                currentEntityId: blade.currentEntityId,
+                currentEntity: blade.currentEntity,
+                data: $scope.index,
+                indexDate: $scope.indexDate,
+                documentType: $scope.widget.documentType,
+                parentRefresh: refresh,
+                controller: 'virtoCommerce.coreModule.searchIndex.indexDetailController',
+                template: 'Modules/$(VirtoCommerce.Core)/Scripts/SearchIndex/blades/index-detail.tpl.html'
+            };
+            bladeNavigationService.showBlade(newBlade, blade);
+        };
 
-    refresh();
-}]);
+        $scope.$watch('blade.currentEntity', updateStatus);
+
+        refresh();
+    }]);


### PR DESCRIPTION
The index widget doesn't correctly show the error color depending on when the modified date of an item was compared to the indexed date. This is fixed by using the same date time format for both date times.