### PR TITLE
Support for confirmation of email addresses.

### DIFF
--- a/VirtoCommerce.CoreModule.Web/Model/SignInResult.cs
+++ b/VirtoCommerce.CoreModule.Web/Model/SignInResult.cs
@@ -1,9 +1,22 @@
-﻿using Microsoft.AspNet.Identity.Owin;
+using Microsoft.AspNet.Identity.Owin;
 
 namespace VirtoCommerce.CoreModule.Web.Model
 {
     public class SignInResult
     {
         public SignInStatus Status { get; set; }
+
+        private bool _emailConfirmationRequired;
+
+        public bool EmailConfirmationRequired
+        {
+            get => _emailConfirmationRequired;
+            set
+            {
+                _emailConfirmationRequired = value;
+                if (value)
+                    Status = SignInStatus.Failure;
+            }
+        }
     }
 }


### PR DESCRIPTION
Add support for confirmation of emails.

Created PasswordSignInIfEmailAddressConfirmed next to PasswordSignIn, though it would be nicer if one method could be used like in https://docs.microsoft.com/en-us/aspnet/core/security/authentication/accconfirm?tabs=aspnetcore2x.

Extended SignInResult as to not break any extended code, but I personally think it would be nicer if the SignInResult wasn't focussed on the Owin sign in status, breaking that hardcoded dependency + making it more easily extensible.

Added a method to confirm your email address.

Everything just uses the standard ApplicationUserManager.

I've not added code that generates the token here. In our case, we have a custom RegistrationEmailObserver that adds the token to a custom email. This could again be a nice improvement depending on a setting.

As discussed on Gitter, I realize that you will take steps towards supporting email confirmation, but I need it now. Would appreciate it if this part could already be added to the standard implementation, with any recommendations you may have. If not, I can add the "ConfirmEmailAddress" method to a custom controller, but it's more difficult to do this for the PasswordSignIn because then I'd have to copy all the logic in there, which I'd like to avoid.