### PR TITLE
Add helper to OrderChangedEvent to allow reuse of logic.

### DIFF
--- a/VirtoCommerce.Domain/Order/Events/OrderChangedEvent.cs
+++ b/VirtoCommerce.Domain/Order/Events/OrderChangedEvent.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.Domain.Order.Model;
+using VirtoCommerce.Domain.Payment.Model;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Domain.Order.Events
@@ -20,5 +17,32 @@ namespace VirtoCommerce.Domain.Order.Events
         public EntryState ChangeState { get; set; }
         public CustomerOrder OrigOrder { get; set; }
         public CustomerOrder ModifiedOrder { get; set; }
+
+        public bool IsOrderNowPaid()
+        {
+            var retVal = false;
+
+            if (OrigOrder != null && ModifiedOrder != null)
+            {
+                foreach (var origPayment in OrigOrder.InPayments)
+                {
+                    var modifiedPayment = ModifiedOrder.InPayments.FirstOrDefault(i => i.Id == origPayment.Id);
+                    if (modifiedPayment != null)
+                    {
+                        var paidSum = ModifiedOrder.InPayments.Where(i => i.PaymentStatus == PaymentStatus.Paid)
+                            .Sum(i => i.Sum);
+                        retVal = modifiedPayment.PaymentStatus == PaymentStatus.Paid &&
+                                 origPayment.PaymentStatus != PaymentStatus.Paid && paidSum == ModifiedOrder.Total;
+                    }
+
+                    if (retVal)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return retVal;
+        }
     }
 }


### PR DESCRIPTION
Add logic that's used in the OrderNotificationObserver to the OrderChangedEvent, so the logic to determine whether an order has just been paid can be reused.