### PR TITLE
Expose Address name on lister & Detail blade

### DIFF
--- a/VirtoCommerce.CoreModule.Web/Localizations/de.VirtoCommerce.Core.json
+++ b/VirtoCommerce.CoreModule.Web/Localizations/de.VirtoCommerce.Core.json
@@ -29,6 +29,7 @@
             "address-detail": {
                 "subtitle": "Adresse bearbeiten",
                 "labels": {
+                    "name": "Adressname",
                     "address-type": "Adresstyp",
                     "first-name": "Vorname",
                     "last-name": "Nachname",

--- a/VirtoCommerce.CoreModule.Web/Localizations/en.VirtoCommerce.Core.json
+++ b/VirtoCommerce.CoreModule.Web/Localizations/en.VirtoCommerce.Core.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "core": {
         "commands": {
             "apply-filter": "Save & apply",
@@ -34,6 +34,7 @@
             "address-detail": {
                 "subtitle": "Edit address",
                 "labels": {
+                    "name":  "Address Name", 
                     "address-type": "Address type",
                     "first-name": "First name",
                     "last-name": "Last name",

--- a/VirtoCommerce.CoreModule.Web/Scripts/common/blades/address-list.js
+++ b/VirtoCommerce.CoreModule.Web/Scripts/common/blades/address-list.js
@@ -1,4 +1,4 @@
-﻿angular.module('virtoCommerce.coreModule.common')
+angular.module('virtoCommerce.coreModule.common')
 .controller('virtoCommerce.coreModule.common.coreAddressListController', ['$timeout', '$scope', 'platformWebApp.bladeNavigationService', function ($timeout, $scope, bladeNavigationService) {
     var blade = $scope.blade;
     $scope.selectedItem = null;
@@ -42,7 +42,11 @@
     }
 
     $scope.getAddressName = function (address) {
-        return [address.countryCode, address.regionName, address.city, address.line1].join(", ");
+        if (address.name) {
+            return address.name;
+        } else {
+            return [address.countryCode, address.regionName, address.city, address.line1].join(", ");
+        }
     };
 
     blade.headIcon = blade.parentBlade.headIcon;

--- a/VirtoCommerce.CoreModule.Web/Scripts/common/common.js
+++ b/VirtoCommerce.CoreModule.Web/Scripts/common/common.js
@@ -1,63 +1,68 @@
 angular.module('virtoCommerce.coreModule.common', [])
     .run(['platformWebApp.metaFormsService', function (metaFormsService) {
         metaFormsService.registerMetaFields('addressDetails', [{
+            name: 'name',
+            title: 'core.blades.address-detail.labels.name',
+            valueType: 'ShortText',
+            priority: 0
+        }, {
             name: 'addressType',
             templateUrl: 'addressTypeSelector.html',
-            priority: 0
+            priority: 1
         }, {
             name: 'firstName',
             title: 'core.blades.address-detail.labels.first-name',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 1
+            priority: 2
         }, {
             name: 'lastName',
             title: 'core.blades.address-detail.labels.last-name',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 2
+            priority: 3
         }, {
             name: 'countryCode',
             templateUrl: 'countrySelector.html',
-            priority: 3
+            priority: 4
         }, {
             name: 'regionName',
             title: 'core.blades.address-detail.labels.region',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 4
+            priority: 5
         }, {
             name: 'city',
             title: 'core.blades.address-detail.labels.city',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 5
+            priority: 6
         }, {
             name: 'line1',
             title: 'core.blades.address-detail.labels.address1',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 6
+            priority: 7
         }, {
             name: 'line2',
             title: 'core.blades.address-detail.labels.address2',
             valueType: 'ShortText',
-            priority: 7
+            priority: 8
         }, {
             name: 'postalCode',
             title: 'core.blades.address-detail.labels.zip-code',
             valueType: 'ShortText',
             isRequired: true,
-            priority: 8
+            priority: 9
         }, {
             name: 'email',
             title: 'core.blades.address-detail.labels.email',
             valueType: 'Email',
-            priority: 9
+            priority: 10
         }, {
             name: 'phone',
             title: 'core.blades.address-detail.labels.phone',
             valueType: 'ShortText',
-            priority: 10
+            priority: 11
         }]);
     }]);


### PR DESCRIPTION
This change exposes the address name on the detail blade. It also uses the address name in the lister. 

In case the field is not filled in, the previous implementation (concat of fields) is used.