### PR TITLE
Expose the id of an address

### DIFF
--- a/VirtoCommerce.Domain/Commerce/Model/Address.cs
+++ b/VirtoCommerce.Domain/Commerce/Model/Address.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,7 +9,8 @@ namespace VirtoCommerce.Domain.Commerce.Model
 {
    public class Address : ValueObject<Address>
 	{
-		public AddressType AddressType { get; set; }
+	    public string Id { get; set; }
+	    public AddressType AddressType { get; set; }
 		public string Name { get; set; }
 		public string Organization { get; set; }
 		public string CountryCode { get; set; }


### PR DESCRIPTION
To be able to differentiate between different addresses that a user or an organization can have, we want to be able to use the unique identifier, but it was not being passed through the api.