### PR TITLE
Update inheritance of *SearchCriteria classes.

### DIFF
--- a/VirtoCommerce.Domain/Cart/Model/Search/ShoppingCartSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Cart/Model/Search/ShoppingCartSearchCriteria.cs
@@ -1,8 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Cart.Model

--- a/VirtoCommerce.Domain/Catalog/Model/Search/SearchCriteria.cs
+++ b/VirtoCommerce.Domain/Catalog/Model/Search/SearchCriteria.cs
@@ -1,11 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Linq;
+using VirtoCommerce.Domain.Commerce.Model.Search;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Domain.Catalog.Model
 {
-    public class SearchCriteria
+    public class SearchCriteria : SearchCriteriaBase
     {
         public SearchCriteria()
         {
@@ -17,7 +17,7 @@ namespace VirtoCommerce.Domain.Catalog.Model
         }
 
         public string StoreId { get; set; }
-        public SearchResponseGroup ResponseGroup { get; set; }
+        public new SearchResponseGroup ResponseGroup { get; set; }
         public string Keyword { get; set; }
 
         /// <summary>
@@ -67,25 +67,11 @@ namespace VirtoCommerce.Domain.Catalog.Model
             }
 
         }
-        public string LanguageCode { get; set; }
 
         /// <summary>
         /// Product or category code
         /// </summary>
         public string Code { get; set; }
-
-        /// <summary>
-        /// Sorting expression property1:asc;property2:desc
-        /// </summary>
-        public string Sort { get; set; }
-
-        public SortInfo[] SortInfos
-        {
-            get
-            {
-                return SortInfo.Parse(Sort).ToArray();
-            }
-        }
 
         //Hides direct linked categories in virtual category displayed only linked category content without itself
         public bool HideDirectLinkedCategories { get; set; }
@@ -97,11 +83,7 @@ namespace VirtoCommerce.Domain.Catalog.Model
         public string Currency { get; set; }
         public decimal? StartPrice { get; set; }
         public decimal? EndPrice { get; set; }
-
-        public int Skip { get; set; }
-
-        public int Take { get; set; }
-
+        
         /// <summary>
         /// All products have index date less that specified
         /// </summary>

--- a/VirtoCommerce.Domain/Commerce/Model/Search/SearchCriteriaBase.cs
+++ b/VirtoCommerce.Domain/Commerce/Model/Search/SearchCriteriaBase.cs
@@ -4,7 +4,7 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Domain.Commerce.Model.Search
 {
-    public abstract class SearchCriteriaBase
+    public abstract class SearchCriteriaBase : ValueObject
     {
         public string ResponseGroup { get; set; }
 
@@ -46,7 +46,6 @@ namespace VirtoCommerce.Domain.Commerce.Model.Search
         public string Sort { get; set; }
 
         public virtual SortInfo[] SortInfos => SortInfo.Parse(Sort).ToArray();
-
 
         public int Skip { get; set; }
         public int Take { get; set; } = 20;

--- a/VirtoCommerce.Domain/Marketing/Model/DynamicContent/Search/DynamicContentItemSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Marketing/Model/DynamicContent/Search/DynamicContentItemSearchCriteria.cs
@@ -1,9 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Marketing.Model.DynamicContent.Search
 {

--- a/VirtoCommerce.Domain/Marketing/Model/DynamicContent/Search/DynamicContentSearchCriteriaBase.cs
+++ b/VirtoCommerce.Domain/Marketing/Model/DynamicContent/Search/DynamicContentSearchCriteriaBase.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Marketing.Model.DynamicContent.Search

--- a/VirtoCommerce.Domain/Marketing/Model/Promotions/Search/PromotionSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Marketing/Model/Promotions/Search/PromotionSearchCriteria.cs
@@ -1,4 +1,4 @@
-﻿using VirtoCommerce.Domain.Commerce.Model.Search;
+using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Marketing.Model.Promotions.Search
 {

--- a/VirtoCommerce.Domain/Order/Model/Search/CustomerOrderSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Order/Model/Search/CustomerOrderSearchCriteria.cs
@@ -98,7 +98,6 @@ namespace VirtoCommerce.Domain.Order.Model
         public string EmployeeId { get; set; }
         public string[] StoreIds { get; set; }
         public DateTime? StartDate { get; set; }
-        public DateTime? EndDate { get; set; }       
-
+        public DateTime? EndDate { get; set; }
     }
 }

--- a/VirtoCommerce.Domain/Pricing/Model/Search/PricelistSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Pricing/Model/Search/PricelistSearchCriteria.cs
@@ -1,8 +1,3 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VirtoCommerce.Domain.Pricing.Model.Search
 {

--- a/VirtoCommerce.Domain/Pricing/Model/Search/PricesSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Pricing/Model/Search/PricesSearchCriteria.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace VirtoCommerce.Domain.Pricing.Model.Search
 {

--- a/VirtoCommerce.Domain/Pricing/Model/Search/PricingSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Pricing/Model/Search/PricingSearchCriteria.cs
@@ -1,36 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Pricing.Model.Search
 {
-    public class PricingSearchCriteria
+    public class PricingSearchCriteria : SearchCriteriaBase
     {
-        public PricingSearchCriteria()
-        {
-            Take = 20;
-        }
-
-    
         public string Keyword { get; set; }
-
-        /// <summary>
-        /// Sorting expression property1:asc;property2:desc
-        /// </summary>
-        public string Sort { get; set; }
-
-        public SortInfo[] SortInfos
-        {
-            get
-            {
-                return SortInfo.Parse(Sort).ToArray();
-            }
-        }
-
-        public int Skip { get; set; }
-        public int Take { get; set; }
     }
 }

--- a/VirtoCommerce.Domain/Quote/Model/Search/QuoteRequestSearchCriteria.cs
+++ b/VirtoCommerce.Domain/Quote/Model/Search/QuoteRequestSearchCriteria.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System;
 using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Quote.Model

--- a/VirtoCommerce.Domain/Store/Model/Search/SearchCriteria.cs
+++ b/VirtoCommerce.Domain/Store/Model/Search/SearchCriteria.cs
@@ -1,37 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Domain.Commerce.Model.Search;
 
 namespace VirtoCommerce.Domain.Store.Model
 {
-    public class SearchCriteria
+    public class SearchCriteria : SearchCriteriaBase
     {
         public SearchCriteria()
         {
             Take = 20;
         }
+
         public string[] StoreIds { get; set; }
 
         public string Keyword { get; set; }
-
-        /// <summary>
-        /// Sorting expression property1:asc;property2:desc
-        /// </summary>
-        public string Sort { get; set; }
-
-        public SortInfo[] SortInfos
-        {
-            get
-            {
-                return SortInfo.Parse(Sort).ToArray();
-            }
-        }
-
-     
-        public int Skip { get; set; }
-
-        public int Take { get; set; }
-
     }
 }


### PR DESCRIPTION
### Problem
For fix issue [#7](https://github.com/VirtoCommerce/vc-module-cache/issues/7) in vc-cache-module all *SearchCriteria classes should realize method 'ICacheKey.GetCacheKey()' which implemented in ValueObject class.

### Solution
Inherit all *SearchCriteria classes from 'SearchCriteriaBase', which inherit from ValueObject.

**Pay attention** on line 20 file SearchCriteria.cs! It's may be problem with serialization/deserialization.. 

### Proposed of changes
Nothing

