### PR TITLE
Cart #28: fixing Swagger validation failures for the CartModule

### DIFF
--- a/VirtoCommerce.Domain/Pricing/Model/PricelistAssignment.cs
+++ b/VirtoCommerce.Domain/Pricing/Model/PricelistAssignment.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using VirtoCommerce.Domain.Common;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -41,6 +42,7 @@ namespace VirtoCommerce.Domain.Pricing.Model
         /// <summary>
         /// Deserialized conditional expression  used to evaluate current assignment availability 
         /// </summary>
+        [JsonIgnore]
         public Func<IEvaluationContext, bool> Condition { get; set; }
 
         /// <summary>

--- a/VirtoCommerce.Domain/Pricing/Model/PricelistAssignment.cs
+++ b/VirtoCommerce.Domain/Pricing/Model/PricelistAssignment.cs
@@ -42,6 +42,8 @@ namespace VirtoCommerce.Domain.Pricing.Model
         /// <summary>
         /// Deserialized conditional expression  used to evaluate current assignment availability 
         /// </summary>
+        // TECHDEBT: [JsonIgnore] attribute here is a workaround to exclude this property from Swagger documentation.
+        //           This property causes NSwag to include lots of types including MethodImplAttributes, which leads to the invalid Swagger JSON.
         [JsonIgnore]
         public Func<IEvaluationContext, bool> Condition { get; set; }
 


### PR DESCRIPTION
This PR is a workaround for the VirtoCommerce/vc-module-cart#28. It prevents the Swagger to make a documentation for the `PricelistAssignment.Condition` property. It is public and has the return type of `Func<IEvaluationContext, bool>`, so it causes NSwag to include lots of reflection-related types, including the `MethodImplAttributes` enumeration. This property can't be properly serialized because it's a delegate, and it can't be used by the frontend or other REST clients (in fact, it probably isn't used anywhere outside of the Pricing module), so this change probably won't break anything.

For more information, please see my [comment to the issue #28](https://github.com/VirtoCommerce/vc-module-cart/issues/28#issuecomment-431840042).