### PR TITLE
Disable commit tagging in synced-main.yml workflow

### DIFF
--- a/.github/workflows/synced-main.yml
+++ b/.github/workflows/synced-main.yml
@@ -135,17 +135,6 @@ jobs:
           connection_string: ${{ secrets.BLOB_CONNECTION_STRING }}
           sync: false
 
-      - name: Add tag "ver.${{ steps.image.outputs.tag }}"
-        if: ${{ env.REPO_TOKEN != 0 && (github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'testing')) }}
-        uses: tvdias/github-tagger@v0.0.2
-        env:
-          REPO_TOKEN: ${{secrets.REPO_TOKEN}}
-        with:
-          repo-token: ${{ secrets.REPO_TOKEN }}
-          tag: ver.${{ needs.build-package.outputs.tag }}
-          # optional commit sha to apply the tag to
-          commit-sha: ${{ needs.build-package.outputs.sha }}
-
       - name: Set Build status Successful
         run: echo "::set-env name=BUILD_STATE::successful"
 


### PR DESCRIPTION
### Problem
When PR merged into dev tag look like ver.3.3.0-SHA adds to commit and shows in the releases page

### Solution
Disable commit tagging in synced-main.yml workflow

### Proposed of changes
Describe the technical details of the realization provided by you.

### Additional context (optional)
`Publish` job step `name: Add tag "ver.${{ steps.image.outputs.tag }}"` in synced-main.yml workflow deleted