### PR TITLE
VP-4020: Fix upload blob storage fails

### DIFF
--- a/.github/workflows/synced-main.yml
+++ b/.github/workflows/synced-main.yml
@@ -1,8 +1,20 @@
 name: CI
 on:
   push:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'docs/**'
+      - 'build/**'
+      - 'README.md'
+      - 'LICENSE'
     branches: [ master, dev ]
 
 jobs:
@@ -128,7 +140,7 @@ jobs:
           }
 
       - name: Upload a Build Artifact to Azure Blob Storage
-        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        uses: bacongobbler/azure-blob-storage-upload@master
         with:
           source_dir: '${{needs.build-package.outputs.path}}'
           container_name: 'packages'


### PR DESCRIPTION
Changed azure-blob-storage-upload version to master
Added path-ignore for push and PR events