### PR TITLE
VP-5178: ShipmentId Issue

### DIFF
--- a/VirtoCommerce.Domain/Order/Model/PaymentIn.cs
+++ b/VirtoCommerce.Domain/Order/Model/PaymentIn.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.Domain.Commerce.Model;
 using VirtoCommerce.Domain.Payment.Model;
 
@@ -10,11 +7,14 @@ namespace VirtoCommerce.Domain.Order.Model
 {
     public class PaymentIn : OrderOperation, IHaveTaxDetalization, ITaxable, IHasDiscounts
     {
+        public string OrderId { get; set; }
+        public string ShipmentId { get; set; }
+
         public string Purpose { get; set; }
         /// <summary>
         /// Payment method (gateway) code
         /// </summary>
-		public string GatewayCode { get; set; }
+        public string GatewayCode { get; set; }
         /// <summary>
         /// Payment method contains additional payment method information
         /// </summary>


### PR DESCRIPTION
VP-5178 #36691 ShipmentId Issue

### Problem
shipmentId always is null

### Solution
Add shipmentId and orderId to PaymnetIn model

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
