### PR TITLE
PT-4392: Between - lower bound is not taken into account

### DIFF
--- a/src/VirtoCommerce.CoreModule.Core/Conditions/CompareConditionBase.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Conditions/CompareConditionBase.cs
@@ -29,7 +29,7 @@ namespace VirtoCommerce.CoreModule.Core.Conditions
             }
             else if (CompareCondition.EqualsInvariant(ConditionOperation.Between))
             {
-                result = leftOperand > rightOperand && leftOperand <= rightSecondOperand;
+                result = leftOperand >= rightOperand && leftOperand <= rightSecondOperand;
             }
             else if (CompareCondition.EqualsInvariant(ConditionOperation.AtLeast) || CompareCondition.EqualsInvariant(ConditionOperation.IsGreaterThanOrEqual))
             {


### PR DESCRIPTION
## Description
Promotion "[] [] items are in shopping cart - between" >lower bound is not taken into account
## References
### QA-test:
### Jira-link:

https://virtocommerce.atlassian.net/browse/PT-4392
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.29.0-pr-200.zip
