### PR TITLE
VCST-2305: Add rounding option to dynamic expression templates

### DIFF
--- a/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
@@ -246,8 +246,8 @@
     <div class="form-input __mini">
         <input money required ng-model="element1.maxLimit">
     </div>
-    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
-    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+    , <a class="__link" left-click-menu data-target="trueFalse_menu_{{element1.$$hashKey}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu_{{element1.$$hashKey}}">
         <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
         <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
     </ul>
@@ -262,8 +262,8 @@
         <input smart-float num-type="integer" required ng-model="element1.numItem">
     </div>items of this product:
     <a class="__link" ng-click="openItemSelectWizard(element1)">{{element1.productName?element1.productName + ' (' + element1.productCode + ')' : 'select product' }}</a>
-    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
-    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+    , <a class="__link" left-click-menu data-target="trueFalse_menu_{{element1.$$hashKey}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu_{{element1.$$hashKey}}">
         <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
         <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
     </ul>
@@ -283,8 +283,8 @@
         items of this product:
         <a class="__link" ng-click="openItemSelectWizard(element1)">{{element1.productName?element1.productName + ' (' + element1.productCode + ')' : 'select product' }}</a>
     </div>
-    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
-    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+    , <a class="__link" left-click-menu data-target="trueFalse_menu_{{element1.$$hashKey}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu_{{element1.$$hashKey}}">
         <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
         <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
     </ul>
@@ -369,8 +369,8 @@
             <input money required ng-model="element1.maxLimit">
         </div>
     </div>
-    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
-    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+    , <a class="__link" left-click-menu data-target="trueFalse_menu_{{element1.$$hashKey}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu_{{element1.$$hashKey}}">
         <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
         <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
     </ul>

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
@@ -238,7 +238,6 @@
     <a class="__link" ng-click="openItemSelectWizard(element1)">{{element1.productName?element1.productName + ' (' + element1.productCode + ')' : 'select product' }}</a>
 </script>
 <script type="text/ng-template" id="expression-RewardItemGetOfRel.html">
-    
     <div class="form-input __mini __number">
         <input smart-float num-type="float" required ng-model="element1.amount">
     </div>% off for
@@ -247,7 +246,12 @@
     <div class="form-input __mini">
         <input money required ng-model="element1.maxLimit">
     </div>
-
+    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
+    </ul>
+     amount per item
 </script>
 <script type="text/ng-template" id="expression-RewardItemGetOfAbsForNum.html">
     $
@@ -258,9 +262,14 @@
         <input smart-float num-type="integer" required ng-model="element1.numItem">
     </div>items of this product:
     <a class="__link" ng-click="openItemSelectWizard(element1)">{{element1.productName?element1.productName + ' (' + element1.productCode + ')' : 'select product' }}</a>
+    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
+    </ul>
+     amount per item
 </script>
 <script type="text/ng-template" id="expression-RewardItemGetOfRelForNum.html">
-    
     <div class="form-input __mini __number">
         <input smart-float num-type="float" required ng-model="element1.amount">
     </div>% off, no more than $
@@ -273,8 +282,13 @@
     <div>
         items of this product:
         <a class="__link" ng-click="openItemSelectWizard(element1)">{{element1.productName?element1.productName + ' (' + element1.productCode + ')' : 'select product' }}</a>
-
     </div>
+    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
+    </ul>
+     amount per item
 </script>
 <script type="text/ng-template" id="expression-RewardShippingGetOfAbsShippingMethod.html">
     $
@@ -355,6 +369,12 @@
             <input money required ng-model="element1.maxLimit">
         </div>
     </div>
+    , <a class="__link" left-click-menu data-target="trueFalse_menu{{element1.id}}">{{ element1.roundAmountPerItem | boolToValue:'round':"don't round"}}</a>
+    <ul class="menu __context" role="menu" id="trueFalse_menu{{element1.id}}">
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=true;'>round</li>
+        <li class="menu-item" ng-click='element1.roundAmountPerItem=false;'>don't round</li>
+    </ul>
+     amount per item
 </script>
 <script type="text/ng-template" id="expression-RewardItemForEveryNumOtherItemInGetOfRel.html">
     For

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/dynamicConditions/all-templates.html
@@ -101,7 +101,7 @@
         <ul class="menu __context" role="menu" id="compareCondition_menu{{element1.id}}">
             <li class="menu-item" ng-click='element1.compareCondition="Exactly";'>exactly</li>
             <li class="menu-item" ng-click='element1.compareCondition="AtLeast";'>at least</li>
-            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exacly or less than</li>
+            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exactly or less than</li>
             <li class="menu-item" ng-click='element1.compareCondition="Between";element1.subTotalSecond = element1.subTotal;'>between</li>
         </ul>
 </script>
@@ -118,7 +118,7 @@
         <ul class="menu __context" role="menu" id="compareCondition_menu{{element1.id}}">
             <li class="menu-item" ng-click='element1.compareCondition="Exactly";'>exactly</li>
             <li class="menu-item" ng-click='element1.compareCondition="AtLeast";'>at least</li>
-            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exacly or less than</li>
+            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exactly or less than</li>
             <li class="menu-item" ng-click='element1.compareCondition="Between";element1.numItemSecond = element1.numItem;'>between</li>
         </ul>
 </script>
@@ -137,7 +137,7 @@
         <ul class="menu __context" role="menu" id="compareCondition_menu{{element1.id}}">
             <li class="menu-item" ng-click='element1.compareCondition="Exactly";'>exactly</li>
             <li class="menu-item" ng-click='element1.compareCondition="AtLeast";'>at least</li>
-            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exacly or less than</li>
+            <li class="menu-item" ng-click='element1.compareCondition="IsLessThanOrEqual";'>exactly or less than</li>
             <li class="menu-item" ng-click='element1.compareCondition="Between";element1.numItemSecond = element1.numItem;'>between</li>
         </ul>
 


### PR DESCRIPTION
## Description
New option `round`/`don't round` for the following rewards:

- $... off for ... specific product items
- ...% off for product ..., no more than $...
- ...% off for ... specific product items, no more than $...
- ...% off for ... of every ... specific product items

![image](https://github.com/user-attachments/assets/27f8770c-8198-4101-9ed6-b76d21c189f7)
## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-2305
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.815.0-pr-233-ec2b.zip