### PR TITLE
VCST-2432: Add global tenant ID option for sequence number generation

### DIFF
--- a/src/VirtoCommerce.CoreModule.Core/Common/SequenceNumberGeneratorOptions.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Common/SequenceNumberGeneratorOptions.cs
@@ -10,5 +10,11 @@ namespace VirtoCommerce.CoreModule.Core.Common
         /// Defines the delay between retries in seconds.
         /// </summary>
         public int RetryDelay { get; set; } = 5;
+
+        /// <summary>
+        /// Defines usage of the static tenant id instead of store id for generating unique number.
+        /// Can be useful when you want to have golobal counter for all stores/tenants.
+        /// </summary>
+        public bool UseGlobalTenantId { get; set; } = false;
     }
 }

--- a/src/VirtoCommerce.CoreModule.Data/Services/SequenceNumberGeneratorService.cs
+++ b/src/VirtoCommerce.CoreModule.Data/Services/SequenceNumberGeneratorService.cs
@@ -141,7 +141,7 @@ namespace VirtoCommerce.CoreModule.Data.Services
         /// <returns></returns>
         protected virtual int RequestNextCounter(string tenantId, CounterOptions counterOptions)
         {
-            var sequenceKey = string.IsNullOrEmpty(tenantId) ? counterOptions.NumberTemplate : $"{tenantId}/{counterOptions.NumberTemplate}";
+            var sequenceKey = GetSequenceKey(tenantId, counterOptions);
 
             using var repository = _repositoryFactory();
             var sequence = repository.Sequences.SingleOrDefault(s => s.ObjectType == sequenceKey);
@@ -177,6 +177,18 @@ namespace VirtoCommerce.CoreModule.Data.Services
             return sequence.Value;
         }
 
+        protected virtual string GetSequenceKey(string tenantId, CounterOptions counterOptions)
+        {
+            if(_options.UseGlobalTenantId)
+            {
+                tenantId = "__GlobalTenant";
+            }
+
+            return string.IsNullOrEmpty(tenantId) ?
+                counterOptions.NumberTemplate :
+                $"{tenantId}/{counterOptions.NumberTemplate}";
+        }
+
         /// <summary>
         /// Returns true if counter should be reset.
         /// </summary>
@@ -193,7 +205,7 @@ namespace VirtoCommerce.CoreModule.Data.Services
                     return currentUtcDate.Date > lastResetDate.Date;
                 case ResetCounterType.Weekly:
                     // Reset every Monday
-                    int daysUntilTargetDay = ((int)DayOfWeek.Monday - (int)lastResetDate.DayOfWeek + 7) % 7;
+                    var daysUntilTargetDay = ((int)DayOfWeek.Monday - (int)lastResetDate.DayOfWeek + 7) % 7;
                     var nextMondayDate = lastResetDate.Date.AddDays(daysUntilTargetDay);
                     return currentUtcDate >= nextMondayDate;
                 case ResetCounterType.Monthly:


### PR DESCRIPTION
## Description
feat: Introduced a new `UseGlobalTenantId` property in the `SequenceNumberGeneratorOptions` class to support a global counter across all tenants/stores. By default, false. Set `VirtoCommerce:SequenceNumberGenerator:UseGlobalTenantId` to true, to enable it.

## References
### QA-test:
### Jira-link:
### Artifact URL:
