### PR TITLE
VCST-2486: Add LocalizedName to OutlineItem

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.815.0</VersionPrefix>
+    <VersionPrefix>3.816.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>

--- a/src/VirtoCommerce.CoreModule.Core/Outlines/OutlineItem.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Outlines/OutlineItem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using VirtoCommerce.CoreModule.Core.Seo;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.CoreModule.Core.Outlines
 {
@@ -33,7 +34,7 @@ namespace VirtoCommerce.CoreModule.Core.Outlines
         /// </summary>
         public string Name { get; set; }
 
-        public IDictionary<string, string> LocalizedName { get; set; }
+        public LocalizedString LocalizedName { get; set; }
 
         /// <summary>
         /// True when this object is linked to the virtual parent.
@@ -49,7 +50,7 @@ namespace VirtoCommerce.CoreModule.Core.Outlines
         {
             var result = MemberwiseClone() as OutlineItem;
             result.SeoInfos = SeoInfos?.Select(x => x.Clone() as SeoInfo).ToList();
-            result.LocalizedName = LocalizedName?.ToDictionary(x => x.Key, x => x.Value);
+            result.LocalizedName = LocalizedName?.Clone() as LocalizedString;
             return result;
         }
     }

--- a/src/VirtoCommerce.CoreModule.Core/Outlines/OutlineItem.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Outlines/OutlineItem.cs
@@ -32,6 +32,9 @@ namespace VirtoCommerce.CoreModule.Core.Outlines
         /// The name of current item
         /// </summary>
         public string Name { get; set; }
+
+        public IDictionary<string, string> LocalizedName { get; set; }
+
         /// <summary>
         /// True when this object is linked to the virtual parent.
         /// </summary>
@@ -46,6 +49,7 @@ namespace VirtoCommerce.CoreModule.Core.Outlines
         {
             var result = MemberwiseClone() as OutlineItem;
             result.SeoInfos = SeoInfos?.Select(x => x.Clone() as SeoInfo).ToList();
+            result.LocalizedName = LocalizedName?.ToDictionary(x => x.Key, x => x.Value);
             return result;
         }
     }

--- a/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
+++ b/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.877.0-alpha.13041-vcst-2486" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
+++ b/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
@@ -13,6 +13,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.877.0-alpha.13041-vcst-2486" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.877.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.877.0-alpha.13041-vcst-2486" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.877.0-alpha.13041-vcst-2486" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.877.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.877.0-alpha.13041-vcst-2486" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.877.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.877.0-alpha.13041-vcst-2486" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.877.0-alpha.13041-vcst-2486" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.877.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.877.0-alpha.13041-vcst-2486" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
+++ b/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.853.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.877.0-alpha.13041-vcst-2486" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Core\VirtoCommerce.CoreModule.Core.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
+++ b/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.877.0-alpha.13041-vcst-2486" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.877.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Core\VirtoCommerce.CoreModule.Core.csproj" />

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -17,7 +17,7 @@
   <iconUrl>Modules/$(VirtoCommerce.Core)/Content/logoVC.png</iconUrl>
   <requireLicenseAcceptance>false</requireLicenseAcceptance>
   <releaseNotes />
-  <copyright>Copyright © 2011-2024 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2011-2025 Virto Commerce. All rights reserved</copyright>
   <tags>security core</tags>
   <assemblyFile>VirtoCommerce.CoreModule.Web.dll</assemblyFile>
   <moduleType>VirtoCommerce.CoreModule.Web.Module, VirtoCommerce.CoreModule.Web</moduleType>

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <id>VirtoCommerce.Core</id>
-  <version>3.815.0</version>
+  <version>3.816.0</version>
   <version-tag />
   <platformVersion>3.853.0</platformVersion>
   <title>Commerce core module</title>

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Core</id>
   <version>3.816.0</version>
   <version-tag />
-  <platformVersion>3.877.0-pr-2876-10fd</platformVersion>
+  <platformVersion>3.877.0</platformVersion>
   <title>Commerce core module</title>
   <description>Common e-commerce domain functionality</description>
   <authors>

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Core</id>
   <version>3.816.0</version>
   <version-tag />
-  <platformVersion>3.877.0-alpha.13041-vcst-2486</platformVersion>
+  <platformVersion>3.877.0-pr-2876-10fd</platformVersion>
   <title>Commerce core module</title>
   <description>Common e-commerce domain functionality</description>
   <authors>

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Core</id>
   <version>3.816.0</version>
   <version-tag />
-  <platformVersion>3.853.0</platformVersion>
+  <platformVersion>3.877.0-alpha.13041-vcst-2486</platformVersion>
   <title>Commerce core module</title>
   <description>Common e-commerce domain functionality</description>
   <authors>


### PR DESCRIPTION
## Description
feat: The `OutlineItem` class in the `VirtoCommerce.CoreModule.Core.Outlines` namespace has been updated to include a new property `LocalizedName`, which is a dictionary for storing localized names.


## References
### QA-test:
### Jira-link:




https://virtocommerce.atlassian.net/browse/VCST-2486
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.816.0-pr-235-a4b2.zip