### PR TITLE
VCST-2687: Add null checks before adding elements to lists

### DIFF
--- a/src/VirtoCommerce.CoreModule.Core/Conditions/ConditionTree.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Conditions/ConditionTree.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.CoreModule.Core.Conditions
         public ConditionTree WithAvailableChildren(params IConditionTree[] availableChildren)
         {
             ArgumentNullException.ThrowIfNull(availableChildren);
-            AvailableChildren.AddRange(availableChildren);
+            AvailableChildren.AddRange(availableChildren.Where(c => c != null));
             return this;
         }
 
@@ -31,14 +31,14 @@ namespace VirtoCommerce.CoreModule.Core.Conditions
         public ConditionTree WithAvailConditions(params IConditionTree[] availConditions)
         {
             ArgumentNullException.ThrowIfNull(availConditions);
-            AvailableChildren.AddRange(availConditions);
+            AvailableChildren.AddRange(availConditions.Where(c => c != null));
             return this;
         }
 
         public ConditionTree WithChildren(params IConditionTree[] children)
         {
             ArgumentNullException.ThrowIfNull(children);
-            Children.AddRange(children);
+            Children.AddRange(children.Where(c => c != null));
             return this;
         }
 
@@ -46,7 +46,7 @@ namespace VirtoCommerce.CoreModule.Core.Conditions
         public ConditionTree WithChildrens(params IConditionTree[] childrenCondition)
         {
             ArgumentNullException.ThrowIfNull(childrenCondition);
-            Children.AddRange(childrenCondition);
+            Children.AddRange(childrenCondition.Where(c => c != null));
             return this;
         }
 


### PR DESCRIPTION
## Description
fix: The changes in `ConditionTree.cs` add null checks to the `WithAvailableChildren`, `WithAvailConditions`, `WithChildren`, and `WithChildrens` methods. This ensures that null values are filtered out from input arrays before being added to the `AvailableChildren` and `Children` lists using the `Where(c => c != null)` LINQ method. These modifications prevent potential `NullReferenceException` errors and enhance code robustness.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2687
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.819.0-pr-238-c37e.zip