### PR TITLE
VCST-4721: Wrong Currency english name

### DIFF
--- a/src/VirtoCommerce.CoreModule.Core/Currency/Currency.cs
+++ b/src/VirtoCommerce.CoreModule.Core/Currency/Currency.cs
@@ -15,6 +15,7 @@ namespace VirtoCommerce.CoreModule.Core.Currency
     public class Currency : ValueObject
     {
         private static IDictionary<string, string> _isoCurrencySymbolDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase).WithDefaultValue(null);
+        private static IDictionary<string, string> _isoCurrencyEnglishNameDict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase).WithDefaultValue(null);
         private Language _language;
         private string _code;
 
@@ -26,6 +27,7 @@ namespace VirtoCommerce.CoreModule.Core.Currency
                 {
                     var ri = new RegionInfo(ci.LCID);
                     _isoCurrencySymbolDict[ri.ISOCurrencySymbol] = ri.CurrencySymbol;
+                    _isoCurrencyEnglishNameDict[ri.ISOCurrencySymbol] = ri.CurrencyEnglishName;
                 }
                 catch (Exception)
                 {
@@ -155,12 +157,15 @@ namespace VirtoCommerce.CoreModule.Core.Currency
             {
                 var cultureInfo = CultureInfo.GetCultureInfo(_language.CultureName);
                 NumberFormat = (NumberFormatInfo)cultureInfo.NumberFormat.Clone();
-                EnglishName = cultureInfo.NumberFormat.CurrencySymbol;
 
-                if (!cultureInfo.IsNeutralCulture && cultureInfo != CultureInfo.InvariantCulture)
+                if (_code != null && _isoCurrencyEnglishNameDict.TryGetValue(_code, out var englishName) && englishName != null)
                 {
-                    var region = new RegionInfo(_language.CultureName);
-                    EnglishName = region.CurrencyEnglishName;
+                    EnglishName = englishName;
+                }
+                else
+                {
+                    // Added fallback for virtual currency like points
+                    EnglishName = string.Empty;
                 }
 
                 string symbol;

--- a/src/VirtoCommerce.CoreModule.Web/package-lock.json
+++ b/src/VirtoCommerce.CoreModule.Web/package-lock.json
@@ -1733,16 +1733,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rechoir": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
@@ -1824,27 +1814,6 @@
         "rimraf": "bin.js"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/schema-utils": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
@@ -1879,13 +1848,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shallow-clone": {

--- a/src/VirtoCommerce.CoreModule.Web/package.json
+++ b/src/VirtoCommerce.CoreModule.Web/package.json
@@ -16,6 +16,9 @@
     "webpack": "^5.105.0",
     "webpack-cli": "^4.10.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
   "webpack": {
     "stats": "verbose"
   }

--- a/tests/VirtoCommerce.CoreModule.Tests/CurrencyTests.cs
+++ b/tests/VirtoCommerce.CoreModule.Tests/CurrencyTests.cs
@@ -1,0 +1,75 @@
+using VirtoCommerce.CoreModule.Core.Common;
+using VirtoCommerce.CoreModule.Core.Currency;
+using Xunit;
+
+namespace VirtoCommerce.CoreModule.Tests
+{
+    public class CurrencyTests
+    {
+        [Theory]
+        [InlineData("en-US", "USD", "US Dollar")]
+        [InlineData("en-US", "EUR", "Euro")]
+        [InlineData("en-US", "GBP", "British Pound")]
+        [InlineData("de-DE", "USD", "US Dollar")]
+        [InlineData("de-DE", "EUR", "Euro")]
+        [InlineData("fr-FR", "GBP", "British Pound")]
+        public void Currency_EnglishName_ShouldMatchCurrencyCode_NotLanguage(string cultureName, string currencyCode, string expectedEnglishName)
+        {
+            // Arrange & Act
+            var currency = new Currency(new Language(cultureName), currencyCode);
+
+            // Assert
+            Assert.Equal(expectedEnglishName, currency.EnglishName);
+        }
+
+        [Fact]
+        public void Currency_EnglishName_ShouldBeOverriddenByExplicitName()
+        {
+            // Arrange
+            var customName = "Custom Currency Name";
+
+            // Act
+            var currency = new Currency(new Language("en-US"), "EUR", customName, "€", 1.0m);
+
+            // Assert
+            Assert.Equal(customName, currency.EnglishName);
+        }
+
+        [Fact]
+        public void Currency_EnglishName_ShouldFallbackToCodeBased_WhenExplicitNameIsEmpty()
+        {
+            // Arrange & Act
+            var currency = new Currency(new Language("en-US"), "EUR", null, "€", 1.0m);
+
+            // Assert
+            Assert.Equal("Euro", currency.EnglishName);
+        }
+
+        [Theory]
+        [InlineData("Miles")]
+        [InlineData("Points")]
+        [InlineData("Tokens")]
+        public void Currency_EnglishName_ShouldBeEmpty_ForNonIsoCurrencyCode(string currencyCode)
+        {
+            // Arrange & Act
+            var currency = new Currency(new Language("en-US"), currencyCode);
+
+            // Assert
+            Assert.Equal(string.Empty, currency.EnglishName);
+        }
+
+        [Fact]
+        public void Currency_SetCultureName_ShouldPreserveCorrectEnglishName()
+        {
+            // Arrange
+            var currency = new Currency(new Language("en-US"), "EUR");
+            Assert.Equal("Euro", currency.EnglishName);
+
+            // Act - changing culture should not change the currency english name
+            currency.CultureName = "de-DE";
+
+            // Assert
+            Assert.Equal("Euro", currency.EnglishName);
+        }
+    }
+}

--- a/tests/VirtoCommerce.CoreModule.Tests/VirtoCommerce.CoreModule.Tests.csproj
+++ b/tests/VirtoCommerce.CoreModule.Tests/VirtoCommerce.CoreModule.Tests.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Tools.Tests/VirtoCommerce.Tools.Tests.csproj
+++ b/tests/VirtoCommerce.Tools.Tests/VirtoCommerce.Tools.Tests.csproj
@@ -4,7 +4,7 @@
     <noWarn>1591;NU1608</noWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Issue that the English name always outputs the default values instead of the item ones.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4721
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.1002.0-pr-247-ad49.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how `Currency.EnglishName` is initialized for all non-invariant cultures and adds a new fallback behavior for non-ISO codes; could affect downstream display/serialization expectations. Dependency overrides in the web package-lock may also impact build environments (Node engine requirements) if not aligned.
> 
> **Overview**
> Fixes incorrect currency English name resolution by deriving `Currency.EnglishName` from the *currency code* (ISO 4217) via a prebuilt lookup, rather than from the current culture/region; for non-ISO/virtual currencies it now falls back to an empty string.
> 
> Adds unit coverage for English-name behavior (code-based mapping, explicit override, culture changes, and non-ISO codes). Also bumps test coverage tooling (`coverlet.collector` to 8.0.0) and updates the web build’s `serialize-javascript` via `overrides`/lockfile changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad49a4eaace6b93b4b1323d9520f77a987895854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->