### PR TITLE
VCST-4516: Mark SEO frontend as obsolete (moved to Seo module)

### DIFF
--- a/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
+++ b/src/VirtoCommerce.CoreModule.Core/VirtoCommerce.CoreModule.Core.csproj
@@ -12,6 +12,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="TimeZoneConverter" Version="7.2.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1016.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.MySql/VirtoCommerce.CoreModule.Data.MySql.csproj
@@ -6,11 +6,11 @@
     <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.PostgreSql/VirtoCommerce.CoreModule.Data.PostgreSql.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.CoreModule.Data.SqlServer/VirtoCommerce.CoreModule.Data.SqlServer.csproj
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Data\VirtoCommerce.CoreModule.Data.csproj" />

--- a/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
+++ b/src/VirtoCommerce.CoreModule.Data/VirtoCommerce.CoreModule.Data.csproj
@@ -10,8 +10,8 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.1" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.5" />
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1016.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.CoreModule.Core\VirtoCommerce.CoreModule.Core.csproj" />

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/de.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/de.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Fulfillment-Center verwalten"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "SEO verwalten",
         "labels": {
           "duplicates-found": "Warnung: Es gibt {{count}} widersprüchliche semantische URLs!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Neues SEO",
         "subtitle": "SEO-Details",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "SEO-Konflikte",
         "labels": {
           "semanticUrl": "Semantische URL",
@@ -248,6 +251,7 @@
         "message": "Das Fulfillment-Center wurde geändert. Möchten Sie die Änderungen speichern?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Änderungen speichern",
         "message": "Die SEO-Informationen wurden geändert. Möchten Sie die Änderungen speichern?"
       },
@@ -277,6 +281,7 @@
         "title": "Fulfillment-Center"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/en.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/en.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Managing fulfillment centers"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Manage SEO",
         "labels": {
           "duplicates-found": "Warning: There are {{count}} conflicting semantic URLs!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "New SEO",
         "subtitle": "SEO details",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "SEO conflicts",
         "labels": {
           "semanticUrl": "Semantic URL",
@@ -248,6 +251,7 @@
         "message": "The fulfillment center has been modified. Do you want to save changes?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Save changes",
         "message": "The SEO information has been modified. Do you want to save changes?"
       },
@@ -277,6 +281,7 @@
         "title": "Fulfillment centers"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/es.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/es.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Gestión de centros de distribución"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Gestionar SEO",
         "labels": {
           "duplicates-found": "Advertencia: ¡Hay {{count}} URL semánticas en conflicto!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Nuevo SEO",
         "subtitle": "Detalles de SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Conflictos de SEO",
         "labels": {
           "semanticUrl": "URL semántica",
@@ -248,6 +251,7 @@
         "message": "El centro de distribución ha sido modificado. ¿Desea guardar los cambios?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Guardar cambios",
         "message": "La información de SEO ha sido modificada. ¿Desea guardar los cambios?"
       },
@@ -277,6 +281,7 @@
         "title": "Centros de distribución"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/fr.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/fr.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Gestion des centres de traitement"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Gérer le SEO",
         "labels": {
           "duplicates-found": "Attention : Il y a {{count}} URL sémantiques en conflit !",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Nouveau SEO",
         "subtitle": "Détails SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Conflits SEO",
         "labels": {
           "semanticUrl": "URL sémantique",
@@ -248,6 +251,7 @@
         "message": "Le centre de traitement a été modifié. Voulez-vous enregistrer les modifications ?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Enregistrer les modifications",
         "message": "Les informations SEO ont été modifiées. Voulez-vous enregistrer les modifications ?"
       },
@@ -277,6 +281,7 @@
         "title": "Centres de traitement"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/it.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/it.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Gestione dei centri di evasione ordini"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Gestisci SEO",
         "labels": {
           "duplicates-found": "Attenzione: Ci sono {{count}} URL semantici in conflitto!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Nuovo SEO",
         "subtitle": "Dettagli SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Conflitti SEO",
         "labels": {
           "semanticUrl": "URL semantico",
@@ -248,6 +251,7 @@
         "message": "Il centro di evasione ordini è stato modificato. Vuoi salvare le modifiche?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Salva modifiche",
         "message": "Le informazioni SEO sono state modificate. Vuoi salvare le modifiche?"
       },
@@ -277,6 +281,7 @@
         "title": "Centri di evasione ordini"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/ja.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/ja.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "フルフィルメントセンターの管理"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "SEOの管理",
         "labels": {
           "duplicates-found": "注意：{{count}}件の競合するセマンティックURLがあります！",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "新しいSEO",
         "subtitle": "SEOの詳細",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "SEOの競合",
         "labels": {
           "semanticUrl": "セマンティックURL",
@@ -248,6 +251,7 @@
         "message": "フルフィルメントセンターが変更されました。変更を保存しますか？"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "変更を保存",
         "message": "SEO情報が変更されました。変更を保存しますか？"
       },
@@ -277,6 +281,7 @@
         "title": "フルフィルメントセンター"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/pl.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/pl.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Zarządzanie centrami realizacji zamówień"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Zarządzaj SEO",
         "labels": {
           "duplicates-found": "Uwaga: Istnieje {{count}} konfliktowych semantycznych URL-i!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Nowe SEO",
         "subtitle": "Szczegóły SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Konflikty SEO",
         "labels": {
           "semanticUrl": "Semantyczny URL",
@@ -248,6 +251,7 @@
         "message": "Centrum realizacji zamówień zostało zmodyfikowane. Czy chcesz zapisać zmiany?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Zapisz zmiany",
         "message": "Informacje SEO zostały zmodyfikowane. Czy chcesz zapisać zmiany?"
       },
@@ -277,6 +281,7 @@
         "title": "Centra realizacji zamówień"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/pt.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/pt.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Gerenciar centros de atendimento"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Gerenciar SEO",
         "labels": {
           "duplicates-found": "Atenção: Existem {{count}} URLs semânticas conflitantes!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Novo SEO",
         "subtitle": "Detalhes do SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Conflitos de SEO",
         "labels": {
           "semanticUrl": "URL semântica",
@@ -248,6 +251,7 @@
         "message": "O centro de atendimento foi modificado. Deseja salvar as alterações?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Salvar alterações",
         "message": "As informações de SEO foram modificadas. Deseja salvar as alterações?"
       },
@@ -277,6 +281,7 @@
         "title": "Centros de atendimento"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/ru.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/ru.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "Управление центрами выполнения заказов"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "Управление SEO",
         "labels": {
           "duplicates-found": "Внимание! Найдено {{count}} конфликтующих семантических URL!",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "Новое SEO",
         "subtitle": "Информация о SEO",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "Конфликты SEO",
         "labels": {
           "semanticUrl": "Семантический URL",
@@ -248,6 +251,7 @@
         "message": "Центр выполнения заказов был изменен. Хотите сохранить изменения?"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "Сохранить изменения",
         "message": "Информация SEO была изменена. Хотите сохранить изменения?"
       },
@@ -277,6 +281,7 @@
         "title": "Центры выполнения заказов"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Localizations/zh.VirtoCommerce.Core.json
+++ b/src/VirtoCommerce.CoreModule.Web/Localizations/zh.VirtoCommerce.Core.json
@@ -134,6 +134,7 @@
         "subtitle": "管理履行中心"
       },
       "seo-list": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-list).",
         "subtitle": "管理SEO",
         "labels": {
           "duplicates-found": "注意：存在 {{count}} 个冲突的语义URL！",
@@ -144,6 +145,7 @@
         }
       },
       "seo-detail": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-detail).",
         "title-new": "新建SEO",
         "subtitle": "SEO详情",
         "labels": {
@@ -172,6 +174,7 @@
         }
       },
       "seo-duplicates": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.blades.seo-duplicates).",
         "subtitle": "SEO冲突",
         "labels": {
           "semanticUrl": "语义URL",
@@ -248,6 +251,7 @@
         "message": "履行中心已被修改。您想保存更改吗？"
       },
       "seo-save": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.dialogs.seo-save).",
         "title": "保存更改",
         "message": "SEO信息已被修改。您想保存更改吗？"
       },
@@ -277,6 +281,7 @@
         "title": "履行中心"
       },
       "seo": {
+        "Obsolete-VC0014": "Moved to VirtoCommerce.Seo module (seo.widgets.seo).",
         "title": "SEO"
       }
     }

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-detail.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-detail.js
@@ -1,3 +1,4 @@
+// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo.seoDetailController)
 angular.module('virtoCommerce.coreModule.seo')
     .controller('virtoCommerce.coreModule.seo.seoDetailController', ['$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.metaFormsService', 'virtoCommerce.storeModule.stores', function ($scope, bladeNavigationService, metaFormsService, storesApi) {
     var blade = $scope.blade;

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-duplicates.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-duplicates.js
@@ -1,3 +1,4 @@
+// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo.seoDuplicatesController)
 angular.module('virtoCommerce.coreModule.seo')
 .controller('virtoCommerce.coreModule.seo.seoDuplicatesController', ['$rootScope', '$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.coreModule.seoApi', function ($rootScope, $scope, bladeNavigationService, seoApi) {
     var blade = $scope.blade;

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-list.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/blades/seo-list.js
@@ -1,3 +1,4 @@
+// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo.seoListController)
 angular.module('virtoCommerce.coreModule.seo')
 .controller('virtoCommerce.coreModule.seo.seoListController', ['$scope', 'platformWebApp.uiGridHelper', 'platformWebApp.bladeNavigationService', 'platformWebApp.dialogService', function ($scope, uiGridHelper, bladeNavigationService, dialogService) {
     var blade = $scope.blade;

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/resources/seoResource.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/resources/seoResource.js
@@ -1,4 +1,5 @@
-﻿angular.module('virtoCommerce.coreModule.seo')
+﻿// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo.seoApi)
+angular.module('virtoCommerce.coreModule.seo')
 .factory('virtoCommerce.coreModule.seoApi', ['$resource', function ($resource) {
     return $resource('api/seoinfos/duplicates', null, {
         batchUpdate: { url: 'api/seoinfos/batchupdate', method: 'PUT' }

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/seo.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/seo.js
@@ -1,1 +1,2 @@
-﻿angular.module("virtoCommerce.coreModule.seo", []);
+﻿// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo)
+angular.module("virtoCommerce.coreModule.seo", []);

--- a/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/widgets/seoWidget.js
+++ b/src/VirtoCommerce.CoreModule.Web/Scripts/SEO/widgets/seoWidget.js
@@ -1,4 +1,5 @@
-﻿angular.module('virtoCommerce.coreModule.seo')
+﻿// Obsolete-VC0014: Moved to VirtoCommerce.Seo module (virtoCommerce.seo.seoWidgetController)
+angular.module('virtoCommerce.coreModule.seo')
 .controller('virtoCommerce.coreModule.seo.seoWidgetController', ['$scope', 'platformWebApp.bladeNavigationService', 'virtoCommerce.coreModule.seoApi', function ($scope, bladeNavigationService, seoApi) {
     var blade = $scope.blade;
     var promise;

--- a/src/VirtoCommerce.CoreModule.Web/module.manifest
+++ b/src/VirtoCommerce.CoreModule.Web/module.manifest
@@ -3,7 +3,7 @@
   <id>VirtoCommerce.Core</id>
   <version>3.1003.0</version>
   <version-tag />
-  <platformVersion>3.1002.0</platformVersion>
+  <platformVersion>3.1016.0</platformVersion>
   <title>Commerce core module</title>
   <description>Common e-commerce domain functionality</description>
   <authors>


### PR DESCRIPTION
## Description

- Marked all SEO frontend files (blades, widget, resource, Angular module) with `Obsolete-VC0014` comments
- Marked SEO localization sections with `Obsolete-VC0014` keys in all 10 language files
- No code or files deleted — cleanup will be done separately

### Marked as obsolete

**JS files** (comment at top of each):
- `Scripts/SEO/seo.js`
- `Scripts/SEO/blades/seo-detail.js`
- `Scripts/SEO/blades/seo-list.js`
- `Scripts/SEO/blades/seo-duplicates.js`
- `Scripts/SEO/widgets/seoWidget.js`
- `Scripts/SEO/resources/seoResource.js`

**Localization sections** (all languages):
- `core.blades.seo-list`
- `core.blades.seo-detail`
- `core.blades.seo-duplicates`
- `core.dialogs.seo-save`
- `core.widgets.seo`

### Related

Companion PR: VirtoCommerce/vc-module-seo — SEO blades moved there


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4516
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Core_3.1003.0-pr-249-edbc.zip

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds obsolescence markers and updates dependency versions; functional behavior should be unchanged aside from any transitive effects from the platform/EF package bumps.
> 
> **Overview**
> Marks the Core module’s legacy SEO frontend as **obsolete** by adding `Obsolete-VC0014` comments to the SEO Angular module, blades, widget, and API resource scripts, pointing reviewers to the replacement `VirtoCommerce.Seo` module.
> 
> Adds `Obsolete-VC0014` entries to the SEO-related localization sections across all supported languages so the deprecation is visible in UI strings.
> 
> Updates module dependencies to `VirtoCommerce.Platform.*` `3.1016.0` and bumps ASP.NET/EF design package versions (`Microsoft.AspNetCore.Mvc.NewtonsoftJson` and `Microsoft.EntityFrameworkCore.Design` to `10.0.5`), and aligns `module.manifest` `platformVersion` to `3.1016.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edbc2cde26a6f1f66fd3fc1c90599b30c9e414d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->